### PR TITLE
Fix Nanomsg_async compilation

### DIFF
--- a/lib/nanomsg_async.ml
+++ b/lib/nanomsg_async.ml
@@ -1,6 +1,8 @@
 open Core.Std
 open Async.Std
 
+module Bytes = Caml.Bytes
+
 open Nanomsg_utils
 open Nanomsg
 


### PR DESCRIPTION
Doesn't compile because core shadow's almost all of Bytes. Explictitly
use Bytes from stdlib.

@vbmithr