### PR TITLE
Tests refactor

### DIFF
--- a/_oasis
+++ b/_oasis
@@ -51,16 +51,27 @@ Executable "nanomsg_bindgen"
   MainIs:           nanomsg_bindgen.ml
   BuildDepends:     ctypes.stubs
 
-Executable "suite"
+Executable "base_suite"
+  Build$:           flag(tests)
+  Install:          false
+  Path:             lib_test
+  MainIs:           base_suite.ml
+  BuildDepends:     nanomsg, oUnit (>= 2.0)
+  CompiledObject:   best
+
+Executable "lwt_suite"
   Build$:           flag(tests) && flag(lwt)
   Install:          false
   Path:             lib_test
-  MainIs:           suite.ml
+  MainIs:           lwt_suite.ml
   BuildDepends:     nanomsg.lwt, oUnit (>= 2.0)
   CompiledObject:   best
 
 Test "nanomsg"
-  Command:          $suite -shards 1 -runner sequential
+  Command:          $base_suite -shards 1 -runner sequential
+
+Test "nanomsg_lwt"
+  Command:          $lwt_suite -shards 1 -runner sequential
 
 AlphaFeatures: ocamlbuild_more_args
 Document "api"

--- a/lib/nanomsg.ml
+++ b/lib/nanomsg.ml
@@ -17,7 +17,7 @@ type proto =
   | Push [@value 80]
   | Pull [@value 81]
   | Surveyor [@value 98]
-  | Respondant [@value 99]
+  | Respondent [@value 99]
   | Bus [@value 112]
   [@@deriving enum, show]
 

--- a/lib/nanomsg.ml
+++ b/lib/nanomsg.ml
@@ -2,7 +2,12 @@ open Nanomsg_utils
 
 type error = string * string
 type socket = int
-type domain = AF_SP [@value 1] | AF_SP_RAW [@@deriving enum]
+
+type domain =
+  | AF_SP [@value 1]
+  | AF_SP_RAW
+  [@@deriving enum, show]
+
 type proto =
   | Pair [@value 16]
   | Pub [@value 32]
@@ -14,7 +19,7 @@ type proto =
   | Surveyor [@value 98]
   | Respondant [@value 99]
   | Bus [@value 112]
-      [@@deriving enum]
+  [@@deriving enum, show]
 
 module Addr = struct
   module V4 = struct

--- a/lib/nanomsg.mli
+++ b/lib/nanomsg.mli
@@ -12,7 +12,7 @@ type proto =
   | Push
   | Pull
   | Surveyor
-  | Respondant
+  | Respondent
   | Bus
   [@@deriving show]
 

--- a/lib/nanomsg.mli
+++ b/lib/nanomsg.mli
@@ -1,5 +1,21 @@
-type domain = AF_SP | AF_SP_RAW
-type proto = Pair | Pub | Sub | Req | Rep | Push | Pull | Surveyor | Respondant | Bus
+type domain =
+  | AF_SP
+  | AF_SP_RAW
+  [@@deriving show]
+
+type proto =
+  | Pair
+  | Pub
+  | Sub
+  | Req
+  | Rep
+  | Push
+  | Pull
+  | Surveyor
+  | Respondant
+  | Bus
+  [@@deriving show]
+
 type socket
 
 module Addr : sig
@@ -8,12 +24,12 @@ module Addr : sig
     | `V4 of Ipaddr.V4.t
     | `V6 of Ipaddr.V6.t
     | `Iface of string ]
-      [@@deriving show]
+    [@@deriving show]
 
   type connect =
     [`V4 of Ipaddr.V4.t | `V6 of Ipaddr.V6.t | `Dns of string] *
     [`V4 of Ipaddr.V4.t | `V6 of Ipaddr.V6.t | `Iface of string] option
-      [@@deriving show]
+    [@@deriving show]
 
   type 'a t = [
     | `Inproc of string

--- a/lib_test/base_suite.ml
+++ b/lib_test/base_suite.ml
@@ -1,8 +1,5 @@
-open Lwt.Infix
 open OUnit2
-
 open Nanomsg
-module NB = Nanomsg_lwt
 
 let bind_addr_test ctx =
   let open Addr in
@@ -91,6 +88,12 @@ let connect_to_string_test ctx =
     (connect_of_string "tcp://dead::beef:1234")
     (`Tcp ((`V6 (Ipaddr.V6.of_string_exn "dead::beef"), None), 1234))
 
+let (>>=?) m msg f =
+  match m with
+  | `Ok v  -> f v
+  | `Error (s1, s2) ->
+    assert_failure (Printf.sprintf "%s: '%s' '%s'" msg s1 s2)
+
 let socket_test ctx =
   let domains = [AF_SP; AF_SP_RAW] in
   let protos = [Pair; Pub; Sub; Req; Rep; Push; Pull; Surveyor; Respondant; Bus] in
@@ -121,8 +124,7 @@ let socket_test ctx =
               ~err:(fun (e, m) -> failwith m);
          )
          protos
-    )
-    domains
+    ) domains
 
 let device_test ctx =
   (* int s1 = nn_socket (AF_SP_RAW, NN_REQ); *)
@@ -144,28 +146,6 @@ let send_recv_fd_test ctx =
   ignore @@ recv_fd sock;
   ignore @@ send_fd sock;
   close_exn sock
-
-let pair_test ctx =
-  let msgs = ["auie"; "uie,"; "yx.k"] in
-  let addr = `Inproc "rdv_point" in
-  let peer1 = socket_exn Pair in
-  let peer2 = socket_exn Pair in
-  let _ = bind peer1 addr in
-  let _ = connect peer2 addr in
-  let rec inner () =
-    Lwt_list.iter_s (fun msg ->
-        NB.send_string peer1 msg >>= fun () ->
-        NB.recv_string peer2 >>= fun recv_msg ->
-        assert_equal msg recv_msg; Lwt.return_unit
-      ) msgs >>= fun () ->
-    Lwt_list.iter_s (fun msg ->
-        NB.send_string peer2 msg >>= fun () ->
-        NB.recv_string peer1 >>= fun recv_msg ->
-        assert_equal msg recv_msg; Lwt.return_unit
-      ) msgs >|= fun () ->
-    close_exn peer1;
-    close_exn peer2
-  in Lwt_main.run @@ inner ()
 
 let reqrep_test ctx =
   let open CCError in
@@ -218,66 +198,6 @@ let pubsub_local_2subs_test ctx =
   assert_equal packet x1;
   assert_equal packet x2
 
-let tcp_pubsub_test ctx =
-  let open Nanomsg_lwt in
-  let inner () =
-    let port = 56352 in
-    wrap_error @@ socket Pub >>= fun pub ->
-    wrap_error @@ socket Sub >>= fun sub ->
-    wrap_error @@ set_ipv4_only pub false >>= fun () ->
-    wrap_error @@ set_ipv4_only sub false >>= fun () ->
-    let _ = bind pub @@ `Tcp (`All, port) in
-    let _ = connect sub @@ `Tcp ((`V6 Ipaddr.V6.localhost, None), port) in
-    wrap_error @@ Nanomsg.subscribe sub "" >>= fun () ->
-    let msg = "bleh" in
-    let len = String.length msg in
-    let recv_msg = Bytes.create @@ String.length msg in
-    let recv_msg' = Bytes.create @@ String.length msg in
-    let open Lwt.Infix in
-    let th = Nanomsg_lwt.send_string pub msg in
-    Nanomsg_lwt.recv_string sub >>= fun str ->
-    assert_equal (Lwt.Return ()) (Lwt.state th);
-    assert_equal msg str;
-    let th = Nanomsg_lwt.send_string_buf pub msg 0 len in
-    Nanomsg_lwt.recv_bytes_buf sub recv_msg 0 >>= fun (_:int) ->
-    assert_equal (Lwt.Return ()) (Lwt.state th);
-    assert_equal msg (Bytes.unsafe_to_string recv_msg);
-    let th = Nanomsg_lwt.send_bytes pub recv_msg in
-    Nanomsg_lwt.recv_bytes_buf sub recv_msg' 0 >|= fun (_:int) ->
-    assert_equal (Lwt.Return ()) (Lwt.state th);
-    assert_equal recv_msg recv_msg';
-    close_exn pub;
-    close sub
-  in Lwt_main.run @@ inner ()
-
-let pipeline_local_test ctx =
-  let open Nanomsg_lwt in
-  let msgs = [|"foo"; "bar"; "baz"|] in
-  let receiver addr =
-    wrap_error @@ socket Pull >>= fun s ->
-    wrap_error @@ bind s addr >>= fun _ ->
-    let rec inner n =
-      if n > 2
-      then wrap_error @@ close s
-      else
-        Nanomsg_lwt.recv_string s >>= fun m ->
-        (assert_equal msgs.(n) m; inner (succ n))
-    in
-    inner 0
-  in
-  let sender addr =
-    wrap_error @@ socket Push >>= fun s ->
-    wrap_error @@ connect s addr >>= fun _ ->
-    Lwt_list.iter_s (Nanomsg_lwt.send_string s) @@ Array.to_list msgs >>= fun () ->
-    Lwt_unix.yield () >>= fun () -> wrap_error @@ close s
-  in
-  Lwt_main.run @@
-    Lwt.join
-      [
-        sender (`Inproc "rdvpoint");
-        receiver (`Inproc "rdvpoint")
-      ]
-
 let suite =
   "Nanomsg">:::
   [
@@ -286,12 +206,9 @@ let suite =
     "connect_to_string" >:: connect_to_string_test;
     "socket" >:: socket_test;
     "send_recv_fd" >:: send_recv_fd_test;
-    "pair" >:: pair_test;
     "reqrep" >:: (fun a -> CCError.get_exn @@ reqrep_test a);
     "pubsub_local" >:: (fun a -> CCError.get_exn @@ pubsub_local_test a);
     "pubsub_local_2subs" >:: (fun a -> CCError.get_exn @@ pubsub_local_2subs_test a);
-    "tcp_pubsub" >:: (fun a -> CCError.get_exn @@ tcp_pubsub_test a);
-    "pipeline_local" >:: pipeline_local_test;
   ]
 
 let () =

--- a/lib_test/base_suite.ml
+++ b/lib_test/base_suite.ml
@@ -96,35 +96,32 @@ let (>>=?) m msg f =
 
 let socket_test ctx =
   let domains = [AF_SP; AF_SP_RAW] in
-  let protos = [Pair; Pub; Sub; Req; Rep; Push; Pull; Surveyor; Respondant; Bus] in
-  List.iter
-    (fun d ->
-       List.iter
-         (fun p ->
-            let open CCError in
-            CCError.catch
-              (socket ~domain:d p >>= fun sock ->
-               domain sock >>= fun sock_domain ->
-               proto sock >>= fun sock_proto ->
-               get_linger sock >>= fun sock_linger ->
-               assert_equal d sock_domain;
-               assert_equal p sock_proto;
-               assert_equal (`Ms 1000) sock_linger;
-               set_linger sock `Inf >>= fun () ->
-               get_linger sock >>= fun sock_linger ->
-               assert_equal `Inf sock_linger;
-               set_send_bufsize sock 256 >>= fun () ->
-               set_recv_bufsize sock 256 >>= fun () ->
-               get_send_bufsize sock >>= fun send_bufsize ->
-               get_recv_bufsize sock >>= fun recv_bufsize ->
-               assert_equal 256 send_bufsize;
-               assert_equal 256 recv_bufsize;
-               close sock)
-              ~ok:(fun () -> ())
-              ~err:(fun (e, m) -> failwith m);
-         )
-         protos
-    ) domains
+  let protos = [Pair; Pub; Sub; Req; Rep; Push; Pull; Surveyor; Respondent; Bus] in
+  List.iter (fun d ->
+    List.iter (fun p ->
+      let open CCError in
+      CCError.catch
+        (socket ~domain:d p >>= fun sock ->
+         domain sock >>= fun sock_domain ->
+         proto sock >>= fun sock_proto ->
+         get_linger sock >>= fun sock_linger ->
+         assert_equal d sock_domain;
+         assert_equal p sock_proto;
+         assert_equal (`Ms 1000) sock_linger;
+         set_linger sock `Inf >>= fun () ->
+         get_linger sock >>= fun sock_linger ->
+         assert_equal `Inf sock_linger;
+         set_send_bufsize sock 256 >>= fun () ->
+         set_recv_bufsize sock 256 >>= fun () ->
+         get_send_bufsize sock >>= fun send_bufsize ->
+         get_recv_bufsize sock >>= fun recv_bufsize ->
+         assert_equal 256 send_bufsize;
+         assert_equal 256 recv_bufsize;
+         close sock)
+        ~ok:(fun () -> ())
+        ~err:(fun (e, m) -> failwith m);
+    ) protos
+  ) domains
 
 let device_test ctx =
   (* int s1 = nn_socket (AF_SP_RAW, NN_REQ); *)
@@ -138,8 +135,7 @@ let device_test ctx =
      bind s1 (`Tcp (`All, 5555)) >>= fun eid1 ->
      socket ~domain:AF_SP_RAW Rep >>= fun s2 ->
      bind s2 (`Tcp (`All, 5556)) >>= fun eid2 ->
-     device s1 s2
-    )
+     device s1 s2)
 
 let send_recv_fd_test ctx =
   let sock = socket_exn Pair in

--- a/lib_test/lwt_suite.ml
+++ b/lib_test/lwt_suite.ml
@@ -1,0 +1,89 @@
+open Lwt.Infix
+open OUnit2
+
+open Nanomsg
+module NB = Nanomsg_lwt
+
+let reqrep_test ctx =
+  let open CCError in
+  let receiver = socket_exn Rep in
+  let sender = socket_exn Req in
+  let _ = bind_exn receiver @@ `Inproc "*" in
+  let _ = connect_exn sender @@ `Inproc "*" in
+  let packet = "testing" in
+  send_string sender packet >>= fun () ->
+  recv_string receiver >>= fun received ->
+  close receiver >>= fun () ->
+  close sender >|= fun () ->
+  assert_equal packet received
+
+let tcp_pubsub_test ctx =
+  let open Nanomsg_lwt in
+  let inner () =
+    let port = 56352 in
+    wrap_error @@ socket Pub >>= fun pub ->
+    wrap_error @@ socket Sub >>= fun sub ->
+    wrap_error @@ set_ipv4_only pub false >>= fun () ->
+    wrap_error @@ set_ipv4_only sub false >>= fun () ->
+    let _ = bind pub @@ `Tcp (`All, port) in
+    let _ = connect sub @@ `Tcp ((`V6 Ipaddr.V6.localhost, None), port) in
+    wrap_error @@ Nanomsg.subscribe sub "" >>= fun () ->
+    let msg = "bleh" in
+    let len = String.length msg in
+    let recv_msg = Bytes.create @@ String.length msg in
+    let recv_msg' = Bytes.create @@ String.length msg in
+    let open Lwt.Infix in
+    let th = Nanomsg_lwt.send_string pub msg in
+    Nanomsg_lwt.recv_string sub >>= fun str ->
+    assert_equal (Lwt.Return ()) (Lwt.state th);
+    assert_equal msg str;
+    let th = Nanomsg_lwt.send_string_buf pub msg 0 len in
+    Nanomsg_lwt.recv_bytes_buf sub recv_msg 0 >>= fun (_:int) ->
+    assert_equal (Lwt.Return ()) (Lwt.state th);
+    assert_equal msg (Bytes.unsafe_to_string recv_msg);
+    let th = Nanomsg_lwt.send_bytes pub recv_msg in
+    Nanomsg_lwt.recv_bytes_buf sub recv_msg' 0 >|= fun (_:int) ->
+    assert_equal (Lwt.Return ()) (Lwt.state th);
+    assert_equal recv_msg recv_msg';
+    close_exn pub;
+    close sub
+  in Lwt_main.run @@ inner ()
+
+let pipeline_local_test ctx =
+  let open Nanomsg_lwt in
+  let msgs = [|"foo"; "bar"; "baz"|] in
+  let receiver addr =
+    wrap_error @@ socket Pull >>= fun s ->
+    wrap_error @@ bind s addr >>= fun _ ->
+    let rec inner n =
+      if n > 2
+      then wrap_error @@ close s
+      else
+        Nanomsg_lwt.recv_string s >>= fun m ->
+        (assert_equal msgs.(n) m; inner (succ n))
+    in
+    inner 0
+  in
+  let sender addr =
+    wrap_error @@ socket Push >>= fun s ->
+    wrap_error @@ connect s addr >>= fun _ ->
+    Lwt_list.iter_s (Nanomsg_lwt.send_string s) @@ Array.to_list msgs >>= fun () ->
+    Lwt_unix.yield () >>= fun () -> wrap_error @@ close s
+  in
+  Lwt_main.run @@
+    Lwt.join
+      [
+        sender (`Inproc "rdvpoint");
+        receiver (`Inproc "rdvpoint")
+      ]
+
+let suite =
+  "Nanomsg">:::
+  [
+    "reqrep" >:: (fun a -> CCError.get_exn @@ reqrep_test a);
+    "tcp_pubsub" >:: (fun a -> CCError.get_exn @@ tcp_pubsub_test a);
+    "pipeline_local" >:: pipeline_local_test;
+  ]
+
+let () =
+  run_test_tt_main suite

--- a/lib_test/lwt_suite.ml
+++ b/lib_test/lwt_suite.ml
@@ -1,10 +1,10 @@
 open Lwt.Infix
-open OUnit2
+open OUnit
 
 open Nanomsg
 module NB = Nanomsg_lwt
 
-let reqrep_test ctx =
+let reqrep_test _ =
   let open CCError in
   let receiver = socket_exn Rep in
   let sender = socket_exn Req in
@@ -17,7 +17,11 @@ let reqrep_test ctx =
   close sender >|= fun () ->
   assert_equal packet received
 
-let tcp_pubsub_test ctx =
+let ok msg = function
+  | `Error m -> assert_failure msg
+  | `Ok v -> v
+
+let tcp_pubsub_test _ =
   let open Nanomsg_lwt in
   let inner () =
     let port = 56352 in
@@ -25,14 +29,14 @@ let tcp_pubsub_test ctx =
     wrap_error @@ socket Sub >>= fun sub ->
     wrap_error @@ set_ipv4_only pub false >>= fun () ->
     wrap_error @@ set_ipv4_only sub false >>= fun () ->
-    let _ = bind pub @@ `Tcp (`All, port) in
-    let _ = connect sub @@ `Tcp ((`V6 Ipaddr.V6.localhost, None), port) in
+    let _ = ok "tcp_pubsub: bind" @@ bind pub @@ `Tcp (`All, port) in
+    let _ = ok "tcp_pubsub: connect" @@ connect sub @@
+      `Tcp ((`V6 Ipaddr.V6.localhost, None), port) in
     wrap_error @@ Nanomsg.subscribe sub "" >>= fun () ->
     let msg = "bleh" in
     let len = String.length msg in
     let recv_msg = Bytes.create @@ String.length msg in
     let recv_msg' = Bytes.create @@ String.length msg in
-    let open Lwt.Infix in
     let th = Nanomsg_lwt.send_string pub msg in
     Nanomsg_lwt.recv_string sub >>= fun str ->
     assert_equal (Lwt.Return ()) (Lwt.state th);
@@ -49,7 +53,7 @@ let tcp_pubsub_test ctx =
     close sub
   in Lwt_main.run @@ inner ()
 
-let pipeline_local_test ctx =
+let pipeline_local_test _ =
   let open Nanomsg_lwt in
   let msgs = [|"foo"; "bar"; "baz"|] in
   let receiver addr =
@@ -71,19 +75,14 @@ let pipeline_local_test ctx =
     Lwt_unix.yield () >>= fun () -> wrap_error @@ close s
   in
   Lwt_main.run @@
-    Lwt.join
-      [
-        sender (`Inproc "rdvpoint");
-        receiver (`Inproc "rdvpoint")
-      ]
+  Lwt.join
+    [ sender (`Inproc "rdvpoint")
+    ; receiver (`Inproc "rdvpoint") ]
 
 let suite =
   "Nanomsg">:::
-  [
-    "reqrep" >:: (fun a -> CCError.get_exn @@ reqrep_test a);
-    "tcp_pubsub" >:: (fun a -> CCError.get_exn @@ tcp_pubsub_test a);
-    "pipeline_local" >:: pipeline_local_test;
-  ]
+  [ "reqrep" >:: (fun a -> CCError.get_exn @@ reqrep_test a)
+  ; "tcp_pubsub" >:: (fun a -> CCError.get_exn @@ tcp_pubsub_test a)
+  ; "pipeline_local" >:: pipeline_local_test ]
 
-let () =
-  run_test_tt_main suite
+let () = ignore (run_test_tt_main suite)


### PR DESCRIPTION
* Split lwt tests into own suite (respect depopts and anticipate async tests)
* Respondant -> Respondent
* Use OUnit for lwt tests as OUnit2 is broken for lwt

@vbmithr Looks like the the rest of the lwt tests fail because EAGAIN is being
ignored. Shouldn't be too hard to fix.