### PR TITLE
use `bigstring` instead of `containers.bigarray`

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -5,7 +5,7 @@ PKG lwt.unix
 PKG lwt.ppx
 PKG oUnit
 PKG containers
-PKG containers.bigarray
+PKG bigstring
 PKG ppx_deriving.std
 PKG async
 

--- a/_oasis
+++ b/_oasis
@@ -24,7 +24,7 @@ Library "nanomsg"
   CSources:         nanomsg_stubs.c
   CCLib:            -lnanomsg
   CCOpt:            -I $pkg_ctypes_stubs
-  BuildDepends:     bytes, ctypes.stubs, containers, containers.bigarray, ipaddr, ppx_deriving.std
+  BuildDepends:     bytes, ctypes.stubs, containers, bigstring, ipaddr, ppx_deriving.std
   BuildTools:       nanomsg_bindgen
 
 Library "nanomsg_lwt"

--- a/lib/nanomsg.ml
+++ b/lib/nanomsg.ml
@@ -233,7 +233,7 @@ let recv_fd sock =
   (Obj.magic fd : Unix.file_descr)
 
 let send_bigstring_buf ?(block=true) sock buf pos len =
-  if pos < 0 || len < 0 || pos + len > CCBigstring.size buf
+  if pos < 0 || len < 0 || pos + len > Bigstring.size buf
   then invalid_arg "bounds";
   let nn_buf = C.nn_allocmsg (Unsigned.Size_t.of_int len) 0 in
   match nn_buf with
@@ -242,14 +242,14 @@ let send_bigstring_buf ?(block=true) sock buf pos len =
     let nn_buf_p = Ctypes.(allocate (ptr void) nn_buf) in
     let ba = Ctypes.(bigarray_of_ptr array1 len
                        Bigarray.char @@ from_voidp char nn_buf) in
-    CCBigstring.blit buf pos ba 0 len;
+    Bigstring.blit buf pos ba 0 len;
     CCError.map ignore @@
     error_if_notequal len
       (fun () -> C.nn_send sock nn_buf_p
           (Unsigned.Size_t.of_int (-1)) (int_of_bool @@ not block))
 
 let send_bigstring ?(block=true) sock buf =
-  send_bigstring_buf ~block sock buf 0 @@ CCBigstring.size buf
+  send_bigstring_buf ~block sock buf 0 @@ Bigstring.size buf
 
 let send_bytes_buf ?(block=true) sock buf pos len =
   if pos < 0 || len < 0 || pos + len > Bytes.length buf
@@ -261,7 +261,7 @@ let send_bytes_buf ?(block=true) sock buf pos len =
     let nn_buf_p = Ctypes.(allocate (ptr void) nn_buf) in
     let ba = Ctypes.(bigarray_of_ptr array1 len
                        Bigarray.char @@ from_voidp char nn_buf) in
-    CCBigstring.blit_of_bytes buf pos ba 0 len;
+    Bigstring.blit_of_bytes buf pos ba 0 len;
     CCError.map ignore @@
     error_if_notequal len
       (fun () -> C.nn_send sock nn_buf_p
@@ -295,16 +295,16 @@ let recv ?(block=true) sock f =
 let recv_bytes_buf ?(block=true) sock buf pos =
   recv ~block sock
     (fun ba ->
-       let len = CCBigstring.size ba in
-       CCBigstring.(blit_to_bytes ba 0 buf pos len);
+       let len = Bigstring.size ba in
+       Bigstring.(blit_to_bytes ba 0 buf pos len);
        len
     )
 
 let recv_bytes ?(block=true) sock =
   recv ~block sock (fun ba ->
-      let len = CCBigstring.size ba in
+      let len = Bigstring.size ba in
       let buf = Bytes.create len in
-      CCBigstring.blit_to_bytes ba 0 buf 0 len;
+      Bigstring.blit_to_bytes ba 0 buf 0 len;
       buf)
 
 let recv_string ?(block=true) sock =

--- a/lib/nanomsg.mli
+++ b/lib/nanomsg.mli
@@ -65,14 +65,14 @@ val device : socket -> socket -> (unit, error) CCError.t
 
 (** {2 Zero-copy I/O} *)
 
-val send_bigstring : ?block:bool -> socket -> CCBigstring.t -> (unit, error) CCError.t
-val send_bigstring_buf : ?block:bool -> socket -> CCBigstring.t -> int -> int -> (unit, error) CCError.t
+val send_bigstring : ?block:bool -> socket -> Bigstring.t -> (unit, error) CCError.t
+val send_bigstring_buf : ?block:bool -> socket -> Bigstring.t -> int -> int -> (unit, error) CCError.t
 val send_string : ?block:bool -> socket -> string -> (unit, error) CCError.t
 val send_string_buf : ?block:bool -> socket -> string -> int -> int -> (unit, error) CCError.t
 val send_bytes : ?block:bool -> socket -> Bytes.t -> (unit, error) CCError.t
 val send_bytes_buf : ?block:bool -> socket -> Bytes.t -> int -> int -> (unit, error) CCError.t
 
-val recv : ?block:bool -> socket -> (CCBigstring.t -> 'a) -> ('a, error) CCError.t
+val recv : ?block:bool -> socket -> (Bigstring.t -> 'a) -> ('a, error) CCError.t
 (** [recv ?block sock f] applies [f] to the received message. The
     argument of [f] gets unallocated after [f] returns, so make sure
     [f] {b never} let a reference to its argument escape. *)

--- a/opam
+++ b/opam
@@ -41,6 +41,7 @@ depends: [
   "containers"
   "ipaddr"
   "ppx_deriving"
+  "bigstring"
   "ounit" {test}
 ]
 


### PR DESCRIPTION
bigstring is more complete and should be available independently of
containers anyway. It is being merged on opam right now (https://github.com/ocaml/opam-repository/pull/5657)