### PR TITLE
Use result

### DIFF
--- a/.merlin
+++ b/.merlin
@@ -4,7 +4,7 @@ PKG ipaddr
 PKG lwt.unix
 PKG lwt.ppx
 PKG oUnit
-PKG containers
+PKG result
 PKG bigstring
 PKG ppx_deriving.std
 PKG async

--- a/_oasis
+++ b/_oasis
@@ -24,7 +24,7 @@ Library "nanomsg"
   CSources:         nanomsg_stubs.c
   CCLib:            -lnanomsg
   CCOpt:            -I $pkg_ctypes_stubs
-  BuildDepends:     bytes, ctypes.stubs, containers, bigstring, ipaddr, ppx_deriving.std
+  BuildDepends:     bytes, ctypes.stubs, result, bigstring, ipaddr, ppx_deriving.std
   BuildTools:       nanomsg_bindgen
 
 Library "nanomsg_lwt"

--- a/lib/nanomsg.mli
+++ b/lib/nanomsg.mli
@@ -49,77 +49,77 @@ type eid
 
 (** {1 Socket management } *)
 type error = string * string
-val socket : ?domain:domain -> proto -> (socket, error) CCError.t
+val socket : ?domain:domain -> proto -> (socket, error) Result.result
 val socket_exn : ?domain:domain -> proto -> socket
-val bind : socket -> Addr.bind Addr.t -> (eid, error) CCError.t
+val bind : socket -> Addr.bind Addr.t -> (eid, error) Result.result
 val bind_exn : socket -> Addr.bind Addr.t -> eid
-val connect : socket -> Addr.connect Addr.t -> (eid, error) CCError.t
+val connect : socket -> Addr.connect Addr.t -> (eid, error) Result.result
 val connect_exn : socket -> Addr.connect Addr.t -> eid
-val shutdown : socket -> eid -> (unit, error) CCError.t
+val shutdown : socket -> eid -> (unit, error) Result.result
 val shutdown_exn : socket -> eid -> unit
-val close : socket -> (unit, error) CCError.t
+val close : socket -> (unit, error) Result.result
 val close_exn : socket -> unit
-val device : socket -> socket -> (unit, error) CCError.t
+val device : socket -> socket -> (unit, error) Result.result
 
 (** {1 I/O } *)
 
 (** {2 Zero-copy I/O} *)
 
-val send_bigstring : ?block:bool -> socket -> Bigstring.t -> (unit, error) CCError.t
-val send_bigstring_buf : ?block:bool -> socket -> Bigstring.t -> int -> int -> (unit, error) CCError.t
-val send_string : ?block:bool -> socket -> string -> (unit, error) CCError.t
-val send_string_buf : ?block:bool -> socket -> string -> int -> int -> (unit, error) CCError.t
-val send_bytes : ?block:bool -> socket -> Bytes.t -> (unit, error) CCError.t
-val send_bytes_buf : ?block:bool -> socket -> Bytes.t -> int -> int -> (unit, error) CCError.t
+val send_bigstring : ?block:bool -> socket -> Bigstring.t -> (unit, error) Result.result
+val send_bigstring_buf : ?block:bool -> socket -> Bigstring.t -> int -> int -> (unit, error) Result.result
+val send_string : ?block:bool -> socket -> string -> (unit, error) Result.result
+val send_string_buf : ?block:bool -> socket -> string -> int -> int -> (unit, error) Result.result
+val send_bytes : ?block:bool -> socket -> Bytes.t -> (unit, error) Result.result
+val send_bytes_buf : ?block:bool -> socket -> Bytes.t -> int -> int -> (unit, error) Result.result
 
-val recv : ?block:bool -> socket -> (Bigstring.t -> 'a) -> ('a, error) CCError.t
+val recv : ?block:bool -> socket -> (Bigstring.t -> 'a) -> ('a, error) Result.result
 (** [recv ?block sock f] applies [f] to the received message. The
     argument of [f] gets unallocated after [f] returns, so make sure
     [f] {b never} let a reference to its argument escape. *)
 
 (** {2 Legacy I/O} *)
 
-val recv_string : ?block:bool -> socket -> (string, error) CCError.t
-val recv_bytes : ?block:bool -> socket -> (Bytes.t, error) CCError.t
-val recv_bytes_buf :?block:bool -> socket -> Bytes.t -> int -> (int, error) CCError.t
+val recv_string : ?block:bool -> socket -> (string, error) Result.result
+val recv_bytes : ?block:bool -> socket -> (Bytes.t, error) Result.result
+val recv_bytes_buf :?block:bool -> socket -> Bytes.t -> int -> (int, error) Result.result
 
 (** {1 Get socket options} *)
 
-val domain : socket -> (domain, error) CCError.t
-val proto : socket -> (proto, error) CCError.t
-val send_fd : socket -> (Unix.file_descr, error) CCError.t
-val recv_fd : socket -> (Unix.file_descr, error) CCError.t
+val domain : socket -> (domain, error) Result.result
+val proto : socket -> (proto, error) Result.result
+val send_fd : socket -> (Unix.file_descr, error) Result.result
+val recv_fd : socket -> (Unix.file_descr, error) Result.result
 
-val get_linger : socket -> ([`Inf | `Ms of int], error) CCError.t
-val get_send_bufsize : socket -> (int, error) CCError.t
-val get_recv_bufsize : socket -> (int, error) CCError.t
-val get_send_timeout : socket -> ([`Inf | `Ms of int], error) CCError.t
-val get_recv_timeout : socket -> ([`Inf | `Ms of int], error) CCError.t
-val get_reconnect_ival : socket -> (int, error) CCError.t
-val get_reconnect_ival_max : socket -> (int, error) CCError.t
-val get_send_prio : socket -> (int, error) CCError.t
-val get_recv_prio : socket -> (int, error) CCError.t
-val get_ipv4only : socket -> (bool, error) CCError.t
+val get_linger : socket -> ([`Inf | `Ms of int], error) Result.result
+val get_send_bufsize : socket -> (int, error) Result.result
+val get_recv_bufsize : socket -> (int, error) Result.result
+val get_send_timeout : socket -> ([`Inf | `Ms of int], error) Result.result
+val get_recv_timeout : socket -> ([`Inf | `Ms of int], error) Result.result
+val get_reconnect_ival : socket -> (int, error) Result.result
+val get_reconnect_ival_max : socket -> (int, error) Result.result
+val get_send_prio : socket -> (int, error) Result.result
+val get_recv_prio : socket -> (int, error) Result.result
+val get_ipv4only : socket -> (bool, error) Result.result
 
 (** {1 Set socket options} *)
 
 (** {2 General} *)
 
-val set_linger : socket -> [`Inf | `Ms of int] -> (unit, error) CCError.t
-val set_send_bufsize : socket -> int -> (unit, error) CCError.t
-val set_recv_bufsize : socket -> int -> (unit, error) CCError.t
-val set_send_timeout : socket -> [`Inf | `Ms of int] -> (unit, error) CCError.t
-val set_recv_timeout : socket -> [`Inf | `Ms of int] -> (unit, error) CCError.t
-val set_reconnect_ival : socket -> int -> (unit, error) CCError.t
-val set_reconnect_ival_max : socket -> int -> (unit, error) CCError.t
-val set_send_prio : socket -> int -> (unit, error) CCError.t
-val set_recv_prio : socket -> int -> (unit, error) CCError.t
-val set_ipv4_only : socket -> bool -> (unit, error) CCError.t
+val set_linger : socket -> [`Inf | `Ms of int] -> (unit, error) Result.result
+val set_send_bufsize : socket -> int -> (unit, error) Result.result
+val set_recv_bufsize : socket -> int -> (unit, error) Result.result
+val set_send_timeout : socket -> [`Inf | `Ms of int] -> (unit, error) Result.result
+val set_recv_timeout : socket -> [`Inf | `Ms of int] -> (unit, error) Result.result
+val set_reconnect_ival : socket -> int -> (unit, error) Result.result
+val set_reconnect_ival_max : socket -> int -> (unit, error) Result.result
+val set_send_prio : socket -> int -> (unit, error) Result.result
+val set_recv_prio : socket -> int -> (unit, error) Result.result
+val set_ipv4_only : socket -> bool -> (unit, error) Result.result
 
 (** {2 PubSub} *)
 
-val subscribe : socket -> string -> (unit, error) CCError.t
-val unsubscribe : socket -> string -> (unit, error) CCError.t
+val subscribe : socket -> string -> (unit, error) Result.result
+val unsubscribe : socket -> string -> (unit, error) Result.result
 
 (** {1 Termination} *)
 

--- a/lib/nanomsg_async.ml
+++ b/lib/nanomsg_async.ml
@@ -21,7 +21,7 @@ let ready sock io_event =
 
 let send_buf blitf lenf sock buf pos len =
   if pos < 0 || len < 0 || pos + len > lenf buf
-  then return @@ CCError.fail ("Internal", "bounds")
+  then return @@ Result.Error ("Internal", "bounds")
   else
     C.nn_allocmsg (Unsigned.Size_t.of_int len) 0 |> function
     | None -> return @@ error ()
@@ -31,13 +31,13 @@ let send_buf blitf lenf sock buf pos len =
                          Bigarray.char @@ from_voidp char nn_buf) in
       blitf buf pos ba 0 len;
       ready sock `Write >>| function
-      | `Bad_fd | `Closed -> CCError.fail ("Internal", "`Bad_fd | `Closed")
+      | `Bad_fd | `Closed -> Result.Error ("Internal", "`Bad_fd | `Closed")
       | `Ready ->
         let _ =
           C.nn_send (Obj.magic sock : int)
             nn_buf_p (Unsigned.Size_t.of_int (-1))
             Symbol.(value_of_name_exn "NN_DONTWAIT") in
-        CCError.return ()
+        Result.Ok ()
 
 let send_bigstring_buf = send_buf Bigstring.blit Bigstring.size
 let send_bytes_buf = send_buf Bigstring.blit_of_bytes Bytes.length
@@ -59,7 +59,7 @@ let recv sock f =
   let ba_start_p = allocate (ptr void) null in
   ready sock `Read >>= function
   | `Bad_fd | `Closed ->
-    return @@ CCError.fail ("Internal", "`Bad_fd | `Closed")
+    return @@ Result.Error ("Internal", "`Bad_fd | `Closed")
   | `Ready ->
     let nb_recv = C.nn_recv (Obj.magic sock : int)
         ba_start_p (Unsigned.Size_t.of_int (-1))
@@ -69,7 +69,7 @@ let recv sock f =
         Bigarray.char (from_voidp char ba_start) in
     f ba >>| fun res ->
     let (_:int) = C.nn_freemsg ba_start in
-    CCError.return res
+    Result.Ok res
 
 let recv_bytes_buf sock buf pos =
   recv sock (fun ba ->
@@ -87,5 +87,5 @@ let recv_bytes sock =
     )
 
 let recv_string sock =
-  recv_bytes sock >>| CCError.map Bytes.unsafe_to_string
+  recv_bytes sock >>| Nanomsg_utils.Res.map Bytes.unsafe_to_string
 

--- a/lib/nanomsg_async.ml
+++ b/lib/nanomsg_async.ml
@@ -39,11 +39,11 @@ let send_buf blitf lenf sock buf pos len =
             Symbol.(value_of_name_exn "NN_DONTWAIT") in
         CCError.return ()
 
-let send_bigstring_buf = send_buf CCBigstring.blit CCBigstring.size
-let send_bytes_buf = send_buf CCBigstring.blit_of_bytes Bytes.length
+let send_bigstring_buf = send_buf Bigstring.blit Bigstring.size
+let send_bytes_buf = send_buf Bigstring.blit_of_bytes Bytes.length
 
 let send_bigstring sock buf =
-  send_bigstring_buf sock buf 0 @@ CCBigstring.size buf
+  send_bigstring_buf sock buf 0 @@ Bigstring.size buf
 
 let send_bytes sock b =
   send_bytes_buf sock b 0 (Bytes.length b)
@@ -73,16 +73,16 @@ let recv sock f =
 
 let recv_bytes_buf sock buf pos =
   recv sock (fun ba ->
-      let len = CCBigstring.size ba in
-      CCBigstring.blit_to_bytes ba 0 buf pos len;
+      let len = Bigstring.size ba in
+      Bigstring.blit_to_bytes ba 0 buf pos len;
       return len
     )
 
 let recv_bytes sock =
   recv sock (fun ba ->
-      let len = CCBigstring.size ba in
+      let len = Bigstring.size ba in
       let buf = Bytes.create len in
-      CCBigstring.blit_to_bytes ba 0 buf 0 len;
+      Bigstring.blit_to_bytes ba 0 buf 0 len;
       return buf
     )
 

--- a/lib/nanomsg_async.mli
+++ b/lib/nanomsg_async.mli
@@ -7,28 +7,28 @@ open Nanomsg
 (** {2 Zero-copy I/O} *)
 
 val send_bigstring : socket -> Bigstring.t ->
-  (unit, error) CCError.t Deferred.t
+  (unit, error) Result.result Deferred.t
 
 val send_bigstring_buf : socket -> Bigstring.t -> int -> int ->
-  (unit, error) CCError.t  Deferred.t
+  (unit, error) Result.result  Deferred.t
 
-val send_string : socket -> string -> (unit, error) CCError.t  Deferred.t
+val send_string : socket -> string -> (unit, error) Result.result  Deferred.t
 
 val send_string_buf : socket -> string -> int -> int ->
-  (unit, error) CCError.t Deferred.t
+  (unit, error) Result.result Deferred.t
 
-val send_bytes : socket -> Bytes.t -> (unit, error) CCError.t Deferred.t
+val send_bytes : socket -> Bytes.t -> (unit, error) Result.result Deferred.t
 
 val send_bytes_buf : socket -> Bytes.t -> int -> int ->
-  (unit, error) CCError.t Deferred.t
+  (unit, error) Result.result Deferred.t
 
-val recv : socket -> (Bigstring.t -> 'a Deferred.t) -> ('a, error) CCError.t Deferred.t
+val recv : socket -> (Bigstring.t -> 'a Deferred.t) -> ('a, error) Result.result Deferred.t
 (** [recv sock f] applies [f] to the received message. The
     argument of [f] gets unallocated after [f] returns, so make sure
     [f] {b never} let a reference to its argument escape. *)
 
 (** {2 Legacy I/O} *)
 
-val recv_string : socket -> (string, error) CCError.t Deferred.t
-val recv_bytes : socket -> (Bytes.t, error) CCError.t  Deferred.t
-val recv_bytes_buf : socket -> Bytes.t -> int -> (int, error) CCError.t Deferred.t
+val recv_string : socket -> (string, error) Result.result Deferred.t
+val recv_bytes : socket -> (Bytes.t, error) Result.result  Deferred.t
+val recv_bytes_buf : socket -> Bytes.t -> int -> (int, error) Result.result Deferred.t

--- a/lib/nanomsg_lwt.ml
+++ b/lib/nanomsg_lwt.ml
@@ -59,11 +59,11 @@ let send_buf blitf lenf sock buf pos len =
                      Symbol.(value_of_name_exn "NN_DONTWAIT")) >|= fun nb_written ->
       ignore nb_written
 
-let send_bigstring_buf = send_buf CCBigstring.blit CCBigstring.size
-let send_bytes_buf = send_buf CCBigstring.blit_of_bytes Bytes.length
+let send_bigstring_buf = send_buf Bigstring.blit Bigstring.size
+let send_bytes_buf = send_buf Bigstring.blit_of_bytes Bytes.length
 
 let send_bigstring sock buf =
-  send_bigstring_buf sock buf 0 @@ CCBigstring.size buf
+  send_bigstring_buf sock buf 0 @@ Bigstring.size buf
 
 let send_bytes sock b =
   send_bytes_buf sock b 0 (Bytes.length b)
@@ -91,16 +91,16 @@ let recv sock f =
 
 let recv_bytes_buf sock buf pos =
   recv sock (fun ba ->
-    let len = CCBigstring.size ba in
-    CCBigstring.blit_to_bytes ba 0 buf pos len;
+    let len = Bigstring.size ba in
+    Bigstring.blit_to_bytes ba 0 buf pos len;
     Lwt.return len
   )
 
 let recv_bytes sock =
   recv sock (fun ba ->
-    let len = CCBigstring.size ba in
+    let len = Bigstring.size ba in
     let buf = Bytes.create len in
-    CCBigstring.blit_to_bytes ba 0 buf 0 len;
+    Bigstring.blit_to_bytes ba 0 buf 0 len;
     Lwt.return buf
   )
 

--- a/lib/nanomsg_lwt.ml
+++ b/lib/nanomsg_lwt.ml
@@ -6,16 +6,16 @@ open Nanomsg
 exception Error of string * string
 
 let wrap_error = function
-  | `Error (name, descr) -> Lwt.fail (Error (name, descr))
-  | `Ok a -> Lwt.return a
+  | Result.Error (name, descr) -> Lwt.fail (Error (name, descr))
+  | Result.Ok a -> Lwt.return a
 
 let bind_error f = function
-  | `Error (name, descr) -> Lwt.fail (Error (name, descr))
-  | `Ok a -> f a
+  | Result.Error (name, descr) -> Lwt.fail (Error (name, descr))
+  | Result.Ok a -> f a
 
 let map_error f = function
-  | `Error (name, descr) -> Lwt.fail (Error (name, descr))
-  | `Ok a -> Lwt.return (f a)
+  | Result.Error (name, descr) -> Lwt.fail (Error (name, descr))
+  | Result.Ok a -> Lwt.return (f a)
 
 let throw () =
   let code = C.nn_errno () in

--- a/lib/nanomsg_lwt.mli
+++ b/lib/nanomsg_lwt.mli
@@ -10,8 +10,8 @@ val map_error : ('a -> 'b) -> ('a, error) CCError.t -> 'b Lwt.t
 
 (** {2 Zero-copy I/O} *)
 
-val send_bigstring : socket -> CCBigstring.t -> unit Lwt.t
-val send_bigstring_buf : socket -> CCBigstring.t -> int -> int -> unit Lwt.t
+val send_bigstring : socket -> Bigstring.t -> unit Lwt.t
+val send_bigstring_buf : socket -> Bigstring.t -> int -> int -> unit Lwt.t
 
 val send_string : socket -> string -> unit Lwt.t
 val send_string_buf : socket -> string -> int -> int -> unit Lwt.t
@@ -19,7 +19,7 @@ val send_string_buf : socket -> string -> int -> int -> unit Lwt.t
 val send_bytes : socket -> Bytes.t -> unit Lwt.t
 val send_bytes_buf : socket -> Bytes.t -> int -> int -> unit Lwt.t
 
-val recv : socket -> (CCBigstring.t -> 'a Lwt.t) -> 'a Lwt.t
+val recv : socket -> (Bigstring.t -> 'a Lwt.t) -> 'a Lwt.t
 (** [recv sock f] applies [f] to the received message. The
     argument of [f] gets unallocated after [f] returns, so make sure
     [f] {b never} let a reference to its argument escape. *)

--- a/lib/nanomsg_lwt.mli
+++ b/lib/nanomsg_lwt.mli
@@ -2,9 +2,9 @@ open Nanomsg
 
 exception Error of string * string
 
-val wrap_error : ('a, error) CCError.t -> 'a Lwt.t
-val bind_error : ('a -> 'b Lwt.t) -> ('a, error) CCError.t -> 'b Lwt.t
-val map_error : ('a -> 'b) -> ('a, error) CCError.t -> 'b Lwt.t
+val wrap_error : ('a, error) Result.result -> 'a Lwt.t
+val bind_error : ('a -> 'b Lwt.t) -> ('a, error) Result.result -> 'b Lwt.t
+val map_error : ('a -> 'b) -> ('a, error) Result.result -> 'b Lwt.t
 
 (** {1 Asynchronous I/O} *)
 

--- a/lib/nanomsg_utils.ml
+++ b/lib/nanomsg_utils.ml
@@ -5,6 +5,30 @@ let int_of_duration = function `Inf -> -1 | `Ms x -> x
 let int_of_bool = function false -> 0 | true -> 1
 let bool_of_int = function 0 -> false | _ -> true
 
+module Opt = struct
+  let map f = function
+    | None -> None
+    | Some x -> Some (f x)
+end
+
+module Res = struct
+  open Result
+
+  let get_exn = function
+    | Ok x -> x
+    | Error _ -> invalid_arg "Result.get_exn"
+  let map f = function
+    | Ok x -> Ok (f x)
+    | Error e -> Error e
+  let (>|=) e f = map f e
+  let (>>=) x f = match x with
+    | Error e -> Error e
+    | Ok x -> f x
+  let catch x ~ok ~err = match x with
+    | Error e -> err e
+    | Ok y -> ok y
+end
+
 module Ipaddr = struct
   include Ipaddr
   let pp = pp_hum
@@ -61,15 +85,15 @@ let error () =
     if code > 156384712
     then Symbol.errvalue_of_errno_exn code
     else "" in
-  `Error (err_value, err_string)
+  Result.Error (err_value, err_string)
 
 let maybe_error cond f =
   let res = f () in
-  if cond res then error () else `Ok res
+  if cond res then error () else Result.Ok res
 
 let maybe_error_ign cond f =
   let res = f () in
-  if cond res then error () else `Ok ()
+  if cond res then error () else Result.Ok ()
 
 let error_if_negative = maybe_error (fun x -> x < 0)
 let error_if_notequal v = maybe_error (fun x -> x <> v)

--- a/lib_test/base_suite.ml
+++ b/lib_test/base_suite.ml
@@ -99,8 +99,8 @@ let socket_test ctx =
   let protos = [Pair; Pub; Sub; Req; Rep; Push; Pull; Surveyor; Respondent; Bus] in
   List.iter (fun d ->
     List.iter (fun p ->
-      let open CCError in
-      CCError.catch
+      let open Nanomsg_utils.Res in
+      catch
         (socket ~domain:d p >>= fun sock ->
          domain sock >>= fun sock_domain ->
          proto sock >>= fun sock_proto ->
@@ -129,7 +129,7 @@ let device_test ctx =
   (* int s2 = nn_socket (AF_SP_RAW, NN_REP); *)
   (* nn_bind (s2, "tcp://eth0:5556"); *)
   (* nn_device (s1, s2); *)
-  let open CCError in
+  let open Nanomsg_utils.Res in
   get_exn
     (socket ~domain:AF_SP_RAW Req >>= fun s1 ->
      bind s1 (`Tcp (`All, 5555)) >>= fun eid1 ->
@@ -144,7 +144,7 @@ let send_recv_fd_test ctx =
   close_exn sock
 
 let reqrep_test ctx =
-  let open CCError in
+  let open Nanomsg_utils.Res in
   let receiver = socket_exn Rep in
   let sender = socket_exn Req in
   let _ = bind_exn receiver @@ `Inproc "*" in
@@ -157,7 +157,7 @@ let reqrep_test ctx =
   assert_equal packet received
 
 let pubsub_local_test ctx =
-  let open CCError in
+  let open Nanomsg_utils.Res in
   let address = `Inproc "t2" in
   socket Sub >>= fun sub ->
   subscribe sub "" >>= fun () ->
@@ -172,7 +172,7 @@ let pubsub_local_test ctx =
   assert_equal packet recv_msg
 
 let pubsub_local_2subs_test ctx =
-  let open CCError in
+  let open Nanomsg_utils.Res in
   let addr1 = `Inproc "tt1" in
   let addr2 = `Inproc "tt2" in
   socket Sub >>= fun sub1 ->
@@ -202,9 +202,9 @@ let suite =
     "connect_to_string" >:: connect_to_string_test;
     "socket" >:: socket_test;
     "send_recv_fd" >:: send_recv_fd_test;
-    "reqrep" >:: (fun a -> CCError.get_exn @@ reqrep_test a);
-    "pubsub_local" >:: (fun a -> CCError.get_exn @@ pubsub_local_test a);
-    "pubsub_local_2subs" >:: (fun a -> CCError.get_exn @@ pubsub_local_2subs_test a);
+    "reqrep" >:: (fun a -> Nanomsg_utils.Res.get_exn @@ reqrep_test a);
+    "pubsub_local" >:: (fun a -> Nanomsg_utils.Res.get_exn @@ pubsub_local_test a);
+    "pubsub_local_2subs" >:: (fun a -> Nanomsg_utils.Res.get_exn @@ pubsub_local_2subs_test a);
   ]
 
 let () =

--- a/lib_test/lwt_suite.ml
+++ b/lib_test/lwt_suite.ml
@@ -5,7 +5,7 @@ open Nanomsg
 module NB = Nanomsg_lwt
 
 let reqrep_test _ =
-  let open CCError in
+  let open Nanomsg_utils.Res in
   let receiver = socket_exn Rep in
   let sender = socket_exn Req in
   let _ = bind_exn receiver @@ `Inproc "*" in
@@ -18,8 +18,8 @@ let reqrep_test _ =
   assert_equal packet received
 
 let ok msg = function
-  | `Error m -> assert_failure msg
-  | `Ok v -> v
+  | Result.Error m -> assert_failure msg
+  | Result.Ok v -> v
 
 let tcp_pubsub_test _ =
   let open Nanomsg_lwt in
@@ -81,8 +81,8 @@ let pipeline_local_test _ =
 
 let suite =
   "Nanomsg">:::
-  [ "reqrep" >:: (fun a -> CCError.get_exn @@ reqrep_test a)
-  ; "tcp_pubsub" >:: (fun a -> CCError.get_exn @@ tcp_pubsub_test a)
+  [ "reqrep" >:: (fun a -> Nanomsg_utils.Res.get_exn @@ reqrep_test a)
+  ; "tcp_pubsub" >:: (fun a -> Nanomsg_utils.Res.get_exn @@ tcp_pubsub_test a)
   ; "pipeline_local" >:: pipeline_local_test ]
 
 let () = ignore (run_test_tt_main suite)

--- a/opam
+++ b/opam
@@ -38,7 +38,7 @@ depends: [
   "oasis" {build}
   "ctypes" {>= "0.3"}
   "ctypes-foreign"
-  "containers"
+  "result"
   "ipaddr"
   "ppx_deriving"
   "bigstring"


### PR DESCRIPTION
replace `CCError.t` with `Result.result`, remove dependency on containers (a few util functions have been added, but not much).