### PR TITLE
[DO NOT MERGE] Add Lwt examples for each of the six scalability protocols

### DIFF
--- a/examples/lwt/bus.ml
+++ b/examples/lwt/bus.ml
@@ -1,0 +1,37 @@
+open Lwt
+
+let peer self_port ports () =
+    Lwt_log.warning_f "starting peer '%d'..." self_port >>
+    let sock = Nanomsg.socket_exn Nanomsg.Bus in
+    let _ =  Nanomsg.bind_exn sock (`Inproc (string_of_int self_port)) in
+    Lwt_unix.sleep 1.0 >>
+    let connect port =
+        if port <> self_port
+        then ignore (Nanomsg.connect_exn sock (`Inproc (string_of_int port))) in
+    List.iter connect ports;
+	let sender () =
+		while%lwt true
+		do
+			let msg = Printf.sprintf "%4X" (Random.int 65536) in
+        	Nanomsg_lwt.send_string sock msg >>
+        	Lwt_log.warning_f "Peer '%d' sent '%s'." self_port msg >>
+			Lwt_unix.sleep (Random.float 1.0)
+		done in
+	let receiver () =
+		while%lwt true
+		do
+        	Nanomsg_lwt.recv_string sock >>= fun msg ->
+        	Lwt_log.warning_f "Peer '%d' received '%s'." self_port msg
+		done in
+	sender () <?> receiver ()
+
+let () =
+    let ports = [9000; 9001; 9002] in
+    Lwt_main.run
+    begin
+        Lwt.async (peer 9000 ports);
+        Lwt.async (peer 9001 ports);
+        Lwt.async (peer 9002 ports);
+        while%lwt true do Lwt_unix.sleep 60.0 done
+    end
+

--- a/examples/lwt/pair.ml
+++ b/examples/lwt/pair.ml
@@ -1,0 +1,39 @@
+open Lwt
+
+type role = Binder | Connector
+
+let string_of_role= function
+	| Binder    -> "binder"
+	| Connector -> "connector"
+
+let peer role () =
+    Lwt_log.warning_f "starting peer '%s'..." (string_of_role role) >>
+    let sock = Nanomsg.socket_exn Nanomsg.Pair in
+	let _ = match role with
+		| Binder    -> Nanomsg.bind_exn sock (Nanomsg.Addr.bind_of_string "inproc://test")
+    	| Connector -> Nanomsg.connect_exn sock (Nanomsg.Addr.connect_of_string "inproc://test") in
+	let sender () =
+		while%lwt true
+		do
+			let msg = Printf.sprintf "%4X" (Random.int 65536) in
+        	Nanomsg_lwt.send_string sock msg >>
+        	Lwt_log.warning_f "Peer '%s' sent '%s'." (string_of_role role) msg >>
+			Lwt_unix.sleep (Random.float 1.0)
+		done in
+	let receiver () =
+		while%lwt true
+		do
+        	Nanomsg_lwt.recv_string sock >>= fun msg ->
+        	Lwt_log.warning_f "Peer '%s' received '%s'." (string_of_role role) msg
+		done in
+	sender () <?> receiver ()
+
+let () =
+    Lwt_main.run
+    begin
+        Lwt.async (peer Binder);
+        Lwt_unix.sleep 1.0 >>= fun () ->
+        Lwt.async (peer Connector);
+        while%lwt true do Lwt_unix.sleep 60.0 done
+    end
+

--- a/examples/lwt/pipeline.ml
+++ b/examples/lwt/pipeline.ml
@@ -1,0 +1,33 @@
+open Lwt
+
+let puller () =
+    Lwt_log.warning_f "Starting puller..." >>
+    let sock = Nanomsg.socket_exn Nanomsg.Pull in
+    let _ = Nanomsg.bind_exn sock (Nanomsg.Addr.bind_of_string "inproc://test") in
+    while%lwt true
+    do
+        Nanomsg_lwt.recv_string sock >>= fun msg ->
+        Lwt_log.warning_f "Puller received '%s'." msg
+    done
+
+let pusher () =
+    Lwt_log.warning_f "Starting pusher..." >>
+    let sock = Nanomsg.socket_exn Nanomsg.Push in
+    let _ = Nanomsg.connect_exn sock (Nanomsg.Addr.connect_of_string "inproc://test") in
+    while%lwt true
+    do
+        let msg = Printf.sprintf "%4X" (Random.int 65536) in
+        Nanomsg_lwt.send_string sock msg >>
+        Lwt_log.warning_f "Pusher sent '%s'." msg >>
+        Lwt_unix.sleep 1.0
+    done
+
+let () =
+    Lwt_main.run
+    begin
+        Lwt.async puller;
+        Lwt_unix.sleep 1.0 >>= fun () ->
+        Lwt.async pusher;
+        while%lwt true do Lwt_unix.sleep 60.0 done
+    end
+

--- a/examples/lwt/pubsub.ml
+++ b/examples/lwt/pubsub.ml
@@ -1,0 +1,38 @@
+open Lwt
+open Result
+
+let publisher () =
+    Lwt_log.warning_f "Starting publisher..." >>
+    let sock = Nanomsg.socket_exn Nanomsg.Pub in
+    let _ = Nanomsg.bind_exn sock (Nanomsg.Addr.bind_of_string "inproc://test") in
+    while%lwt true
+    do
+        let msg = Printf.sprintf "%04X" (Random.int 65536) in
+        Nanomsg_lwt.send_string sock msg >>
+        Lwt_log.warning_f "Publisher sent '%s'." msg >>
+        Lwt_unix.sleep 1.0
+    done
+
+let subscriber prefix () =
+    Lwt_log.warning_f "Starting subscriber '%s'..." prefix >>
+    let sock = Nanomsg.socket_exn Nanomsg.Sub in
+    begin match Nanomsg.subscribe sock prefix with
+        | Ok ()        -> Lwt_log.warning_f "Subscriber '%s' successfully limited subscription..." prefix
+        | Error (v, s) -> Lwt_log.error_f "Subscriber '%s' unable to limit subscription: %s, %s" prefix v s
+    end >>
+    let _ = Nanomsg.connect_exn sock (Nanomsg.Addr.connect_of_string "inproc://test") in
+    while%lwt true
+    do
+        Nanomsg_lwt.recv_string sock >>= fun msg ->
+        Lwt_log.warning_f "Subscriber '%s' received '%s'." prefix msg
+    done
+
+let () =
+    Lwt_main.run
+    begin
+        Lwt.async publisher;
+        Lwt_unix.sleep 1.0 >>= fun () ->
+        String.iter (fun prefix -> Lwt.async (subscriber (String.make 1 prefix))) "0123456789ABCDEF";
+        while%lwt true do Lwt_unix.sleep 60.0 done
+    end
+

--- a/examples/lwt/reqrep.ml
+++ b/examples/lwt/reqrep.ml
@@ -1,0 +1,37 @@
+open Lwt
+
+let requester () =
+    Lwt_log.warning_f "Starting requester..." >>
+    let sock = Nanomsg.socket_exn Nanomsg.Req in
+    let _ = Nanomsg.connect_exn sock (Nanomsg.Addr.connect_of_string "inproc://test") in
+    while%lwt true
+    do
+        let msg_req = string_of_int (Random.int 100) in
+        Nanomsg_lwt.send_string sock msg_req >>
+        Lwt_log.warning_f "Requester sent '%s'." msg_req >>
+        Nanomsg_lwt.recv_string sock >>= fun msg_rep ->
+        Lwt_log.warning_f "Requester received '%s' as reply to '%s'." msg_rep msg_req >>
+        Lwt_unix.sleep 1.0
+    done
+
+let replier () =
+    Lwt_log.warning_f "Starting replier..." >>
+    let sock = Nanomsg.socket_exn Nanomsg.Rep in
+    let _ = Nanomsg.bind_exn sock (Nanomsg.Addr.bind_of_string "inproc://test") in
+    while%lwt true
+    do
+        Nanomsg_lwt.recv_string sock >>= fun msg_req ->
+        Lwt_log.warning_f "Replier received '%s'." msg_req >>
+        let msg_rep = msg_req |> int_of_string |> (+) 1 |> string_of_int in
+        Nanomsg_lwt.send_string sock msg_rep >>
+        Lwt_log.warning_f "Replier replied '%s' to request '%s'." msg_rep msg_req
+    done
+
+let () =
+    Lwt_main.run
+    begin
+        Lwt.async requester;
+        Lwt.async replier;
+        while%lwt true do Lwt_unix.sleep 60.0 done
+    end
+

--- a/examples/lwt/survey.ml
+++ b/examples/lwt/survey.ml
@@ -1,0 +1,43 @@
+open Lwt
+
+let surveyor () =
+    Lwt_log.warning_f "Starting surveyor..." >>
+    let sock = Nanomsg.socket_exn Nanomsg.Surveyor in
+    let _ = Nanomsg.bind_exn sock (Nanomsg.Addr.bind_of_string "inproc://test") in
+    while%lwt true
+    do
+        Lwt_unix.sleep 1.0 >>
+        let msg_sur = string_of_int (Random.int 10) in
+        Nanomsg_lwt.send_string sock msg_sur >>
+        Lwt_log.warning_f "Surveyor starting new survey: sent '%s'." msg_sur >>
+        let rec loop () =
+            try%lwt
+                Nanomsg_lwt.recv_string sock >>= fun msg_res ->
+                Lwt_log.warning_f "Surveyor received '%s'." msg_res >>
+                loop ()
+            with _ ->
+                Lwt_log.warning_f "Surveyor finished!" in
+        loop ()
+    done
+
+let respondent prefix () =
+    Lwt_log.warning_f "Starting respondent '%s'..." prefix >>
+    let sock = Nanomsg.socket_exn Nanomsg.Respondent in
+    let _ = Nanomsg.connect_exn sock (Nanomsg.Addr.connect_of_string "inproc://test") in
+    while%lwt true
+    do
+        Nanomsg_lwt.recv_string sock >>= fun msg_sur ->
+        Lwt_log.warning_f "Respondent '%s' received '%s'." prefix msg_sur >>
+        let msg_res = prefix ^ msg_sur in
+        Nanomsg_lwt.send_string sock msg_res >>
+        Lwt_log.warning_f "Respondent '%s' replied '%s'." prefix msg_res
+    done
+
+let () =
+    Lwt_main.run
+    begin
+        Lwt.async surveyor;
+        String.iter (fun prefix -> Lwt.async (respondent (String.make 1 prefix))) "ABCD";
+        while%lwt true do Lwt_unix.sleep 60.0 done
+    end
+


### PR DESCRIPTION
Here are examples for each of the six scalability protocols, using Lwt.  Please do not merge yet, as there still a number of issues to be fixed with some protocols.  I don't know if these issues are due to my misuse of the library, or if they are also present upstream (I'm using release 1.0 of libnanomsg).  If anyone can test these, it would be  much appreciated!

 * `bus`: messages are received in duplicate.
 * `pair`: fatal error.
 * `pubsub`: fatal error.

The other examples (`pipeline`, `reqrep`, and `survey`) seem to be working fine.