### PR TITLE
Changed some things to be compatible with async interface changes

### DIFF
--- a/lib/nanomsg_async.mli
+++ b/lib/nanomsg_async.mli
@@ -1,5 +1,4 @@
-open Core.Std
-open Async.Std
+open Async
 open Nanomsg
 
 (** {1 Asynchronous I/O} *)


### PR DESCRIPTION
Dropped the use of the error polymorphic variants, inside `send_buf` made the use of `blitf` use named arguments, changed the use of `blit_of_bytes` to `Bigstring.From_string.blit` and replaced `Bigstring.size` usage with `Bigstring.length` instead & changed `blit_to_bytes` to `To_string.blit` to make it compilable.