### PR TITLE
Upgrade to ipaddr.3.0.0

### DIFF
--- a/lib/nanomsg.ml
+++ b/lib/nanomsg.ml
@@ -24,12 +24,12 @@ type proto =
 module Addr = struct
   module V4 = struct
     include Ipaddr.V4
-    let pp = pp_hum
+    let pp = pp
   end
 
   module V6 = struct
     include Ipaddr.V6
-    let pp = pp_hum
+    let pp = pp
   end
 
   type bind = [

--- a/lib/nanomsg_utils.ml
+++ b/lib/nanomsg_utils.ml
@@ -31,7 +31,7 @@ end
 
 module Ipaddr = struct
   include Ipaddr
-  let pp = pp_hum
+  let pp = pp
 end
 
 module Symbol = struct

--- a/opam
+++ b/opam
@@ -39,7 +39,7 @@ depends: [
   "ctypes" {>= "0.3"}
   "ctypes-foreign"
   "result"
-  "ipaddr"
+  "ipaddr" {>= "3.0.0"}
   "ppx_deriving"
   "bigstring"
   "ounit" {test}


### PR DESCRIPTION
The latest release of [`ipaddr` 3.0.0](https://github.com/mirage/ocaml-ipaddr/blob/master/CHANGES.md#300-2019-01-02) renamed the `Ipaddr.pp_hum` function to `Ipaddr.pp`. This patch updates the name and adds a version constraint for `ipaddr` in the opam file.